### PR TITLE
Fix bug when finding previous/next revision

### DIFF
--- a/git-timemachine.el
+++ b/git-timemachine.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'vc-git)
+(require 'cl-lib)
 
 (defcustom git-timemachine-abbreviation-length 12
  "Number of chars from the full sha1 hash to use for abbreviation."
@@ -74,15 +75,23 @@ will be shown in the minibuffer while navigating commits."
  (interactive)
  (git-timemachine-show-revision (car (git-timemachine--revisions))))
 
+(defun git-timemachine--next-revision (revisions)
+  "Return the revision following the current revision in REVISIONS."
+  (cadr (cl-member
+         (car git-timemachine-revision) ;; takes the hash
+         revisions
+         :key #'car ;; only compare hashes
+         :test #'string=)))
+
 (defun git-timemachine-show-previous-revision ()
- "Show previous revision of file."
- (interactive)
- (git-timemachine-show-revision (cadr (member git-timemachine-revision (git-timemachine--revisions)))))
+  "Show previous revision of file."
+  (interactive)
+  (git-timemachine-show-revision (git-timemachine--next-revision (git-timemachine--revisions))))
 
 (defun git-timemachine-show-next-revision ()
- "Show next revision of file."
- (interactive)
- (git-timemachine-show-revision (cadr (member git-timemachine-revision (reverse (git-timemachine--revisions))))))
+  "Show next revision of file."
+  (interactive)
+  (git-timemachine-show-revision (git-timemachine--next-revision (reverse (git-timemachine--revisions)))))
 
 (defun git-timemachine-show-revision (revision)
  "Show a REVISION (commit hash) of the current file."


### PR DESCRIPTION
The problem was that sometimes, the information in
`git-timemachine-revision` is not exactly the same as the information
found in `(git-timemachine--revisions)`. For example, the
`git-timemachine--revision`

  ("853c..." 110 "9 seconds ago" "Thu Mar 26 05:53:41 2015 +0000")

has not the same relative date as the first element of
`(git-timemachine--revisions)`:

  (("853c..." 110 "2 minutes ago" "Thu Mar 26 05:53:41 2015 +0000") ...)

The patch I propose makes sure that only the hash is compared, not the
meta-data.