### PR TITLE
Add ability to checkout current file revision

### DIFF
--- a/git-timemachine.el
+++ b/git-timemachine.el
@@ -214,6 +214,16 @@ When passed a GIT-BRANCH, lists revisions from that branch."
   (message revision)
   (kill-new revision)))
 
+(defun git-timemachine-checkout-revision ()
+ "Checkout the current revision"
+ (interactive)
+ (let ((revision (git-timemachine-abbreviate (car git-timemachine-revision)))
+       (revision-file-name (nth 1 git-timemachine-revision)))
+  (message "Checking out %s of %s" revision revision-file-name)
+  (vc-git-command nil 0 revision-file-name "checkout" revision "--")
+  (when (not (string-equal revision-file-name git-timemachine-file))
+   (vc-git-command nil 0 git-timemachine-file "rm" "--"))))
+
 (define-minor-mode git-timemachine-mode
  "Git Timemachine, feel the wings of history."
  :init-value nil
@@ -224,7 +234,8 @@ When passed a GIT-BRANCH, lists revisions from that branch."
    ("g" . git-timemachine-show-nth-revision)
    ("q" . git-timemachine-quit)
    ("w" . git-timemachine-kill-abbreviated-revision)
-   ("W" . git-timemachine-kill-revision))
+   ("W" . git-timemachine-kill-revision)
+   ("C" . git-timemachine-checkout-revision))
  :group 'git-timemachine)
 
 (defun git-timemachine-validate (file)


### PR DESCRIPTION
Add git-timemachine-checkout-revision, bound to "C" on the keymap.
Allows one to checkout the current revision of the file being looked
at.  If the file has been renamed, checkout the revision file and
remove the current file.

See also https://github.com/pidu/git-timemachine/issues/28
