### PR TITLE
Issue 58 - commit details illegible with light themes

### DIFF
--- a/git-timemachine.el
+++ b/git-timemachine.el
@@ -48,14 +48,20 @@ will be shown in the minibuffer while navigating commits."
  :group 'git-timemachine)
 
 (defface git-timemachine-minibuffer-detail-face
- '((t (:foreground "yellow")))
- "How to display the minibuffer detail"
- :group 'git-timemachine)
+  '((((class color) (background dark))
+     :foreground "yellow")
+    (((class color) (background light))
+     :foreground "yellow4"))
+  "How to display the minibuffer detail"
+  :group 'git-timemachine)
 
 (defface git-timemachine-minibuffer-author-face
- '((t (:foreground "orange")))
- "How to display the author in minibuffer"
- :group 'git-timemachine)
+  '((((class color) (background dark))
+     :foreground "orange")
+    (((class color) (background light))
+     :foreground "DarkOrange4"))
+  "How to display the author in minibuffer"
+  :group 'git-timemachine)
 
 (defcustom git-timemachine-minibuffer-detail
  'subject


### PR DESCRIPTION
This adjusts the detail and author faces depending on the class of the display.  Without this, the commit details were often not legible on light themes (e.g. the built-in dichromacy).